### PR TITLE
Add various dev libraries to allow install of R packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     ## Install python 3 and system dependencies
         && apt-get install -y --no-install-recommends build-essential procps libpq-dev python3.8 python3-pip python3-setuptools python3-dev python3.11-venv \
+    ##
+    ## Libs for R-packages (need to compile various packages like tidyverse, devtools, Cairo)
+    ##
+        && apt-get install -y libcurl4-openssl-dev libfontconfig1-dev libxml2-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libcairo2-dev \
     ## Install bed tools
         && apt-get install bedtools \
     ## Move python usr library
@@ -36,7 +40,6 @@ RUN apt-get update \
             pandas
 
 ENV PYTHONPATH "${PYTHONPATH}:/app"
-
 
 
 FROM base AS build


### PR DESCRIPTION
A number of dev libraries need to be installed to allow several of the R packages to compile and install. Note durning the build if an R packages fails to install there is an error message but the build continues. Need to look at logs or check that packages actually work.